### PR TITLE
 #166079174 Add CI badges to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,13 @@
 # AUTOMART
+
+[![Build Status](https://travis-ci.org/kazungusafari/AUTOMART.svg?branch=feature)](https://travis-ci.org/kazungusafari/AUTOMART)
+
+[![Coverage Status](https://coveralls.io/repos/github/kazungusafari/AUTOMART/badge.svg)](https://coveralls.io/github/kazungusafari/AUTOMART)
+
+[![Maintainability](https://api.codeclimate.com/v1/badges/c4b809acd8c65de039bc/maintainability)](https://codeclimate.com/github/kazungusafari/AUTOMART/maintainability)
+
+[![Test Coverage](https://api.codeclimate.com/v1/badges/c4b809acd8c65de039bc/test_coverage)](https://codeclimate.com/github/kazungusafari/AUTOMART/test_coverage)
+
 Auto Mart is an online marketplace for automobiles of diverse makes, model or body type. With Auto Mart, users can sell their cars or buy from trusted dealerships or private sellers.
 
 


### PR DESCRIPTION
What does this PR do?
Add CI badges to Readme

Description of Task to completed?
Have the following achieved
1.Add maintainability  and test coverage badges from codeclimate website
2.Add build badge from TravisCi website
3.Add test coverage badge from coveralls

How should this be manually tested?
After cloning this repository,check Readme and see if it has these badges

What are relevant pivotal tracker story?
#166079174

